### PR TITLE
Fix obscure RevyTeX bug.

### DIFF
--- a/scripts/revy.sty
+++ b/scripts/revy.sty
@@ -276,7 +276,7 @@
 \def\@sings#1{\rm\item [\hskip\@leftsingpad{\bf #1\,}:\hskip
   \@rightsingpad]\hskip-\songhangindent}
 
-\def\sings#1{\@ifnextchar [{\@singsas{#1}}{\@sings{#1}}}
+\def\sings#1{{\@ifnextchar [{\@singsas{#1}}{\@sings{#1}}}}
 
 % Dirty stuff
 % \obeycr = make carriage returns into linebreaks,


### PR DESCRIPTION
Before the fix, the following LaTeX code would fail to compile.

\documentclass[a4paper,11pt]{article}

\usepackage{revy}
\usepackage[utf8]{inputenc}
\usepackage[T1]{fontenc}
\usepackage[danish]{babel}

\revyname{DIKUrevy}
\revyyear{2016}
\version{0.1}
\eta{$n$ minutter}
\status{Ikke færdig}

\title{Fejl}
\author{Niels}
\melody{Fejl}

\begin{document}
\maketitle

\begin{song}
\sings{S} plus
\end{song}

\end{document}